### PR TITLE
Pom.xml fix to allow installation as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 						</goals>
 						<configuration>
 							<target>
-								<move file="${project.build.directory}/${project.build.finalName}.war"
+								<copy file="${project.build.directory}/${project.build.finalName}.war"
 									  tofile="${project.build.directory}/lonestar.war" />
 							</target>
 						</configuration>


### PR DESCRIPTION
Changed the build rename task from a move to a copy, in order to keep a copy of the original war, which is necessary for mvn install task